### PR TITLE
Update CA signature for test.vo VOMS server

### DIFF
--- a/modules/puppet-test-vos/manifests/test_vo.pp
+++ b/modules/puppet-test-vos/manifests/test_vo.pp
@@ -6,7 +6,7 @@ class puppet-test-vos::test_vo {
       { server => 'vgrid02.cnaf.infn.it',
       port => '15000',
       dn => '/C=IT/O=INFN/OU=Host/L=CNAF/CN=vgrid02.cnaf.infn.it',
-      ca_dn => '/C=IT/O=INFN/CN=INFN CA'
+      ca_dn => '/C=IT/O=INFN/CN=INFN Certification Authority'
       }
     ]
   }


### PR DESCRIPTION
vgrid02 host certificate expired and the newer certificate is signed by INFN Certification Authority instead of INFN CA
